### PR TITLE
Fixed the problem of index out of range when n_src<i<max_rank

### DIFF
--- a/src/dico_builder.py
+++ b/src/dico_builder.py
@@ -26,7 +26,7 @@ def get_candidates(emb1, emb2, params):
     # number of source words to consider
     n_src = emb1.size(0)
     if params.dico_max_rank > 0 and not params.dico_method.startswith('invsm_beta_'):
-        n_src = params.dico_max_rank
+        n_src = min(params.dico_max_rank, n_src)
 
     # nearest neighbors
     if params.dico_method == 'nn':


### PR DESCRIPTION
Fixing a problem encountered here at #76 

The problem that led to #76 is that when using methods other than invsm, the code re-assigns `n_src` with `params.dico_max_rank` [here](https://github.com/facebookresearch/MUSE/blob/master/src/dico_builder.py#L28-L29). Yet `params.dico_max_rank` can potentially be larger than the original `n_src`. This will lead to later indexing into an empty slice once `n_src < i < params.dico_max_rank` and trying to transpose it [(here)](https://github.com/facebookresearch/MUSE/blob/master/src/dico_builder.py#L38), causing the error eventually.