### PR TITLE
Handle wrong lines in the dictionary (empty line or unknown symbols)

### DIFF
--- a/src/evaluation/word_translation.py
+++ b/src/evaluation/word_translation.py
@@ -54,9 +54,13 @@ def load_dictionary(path, word2id1, word2id2):
     not_found2 = 0
 
     with io.open(path, 'r', encoding='utf-8') as f:
-        for _, line in enumerate(f):
+        for index, line in enumerate(f):
             assert line == line.lower()
-            word1, word2 = line.rstrip().split()
+            parts = line.rstrip().split()
+            if len(parts) < 2:
+                logger.warning("Could not parse line %s (%i)", line, index)
+                continue
+            word1, word2 = parts
             if word1 in word2id1 and word2 in word2id2:
                 pairs.append((word1, word2))
             else:


### PR DESCRIPTION
I had some error with dictionaries which I generated. Some of the words/symbols cannot be read from python and there is an error in line 60 in word_translation - ` ValueError: not  enough values to unpack (expected 2, got 0) `
I manage to check this in if and to show and ignore these words.

My case is supervised with dico-train default with my custom dictionaries.