### PR TITLE
fastText module is changed to fasttext per June 25,2019

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -73,7 +73,7 @@ def load_fasttext_model(path):
     Load a binarized fastText model.
     """
     try:
-        import fastText
+        import fasttext as fastText
     except ImportError:
         raise Exception("Unable to import fastText. Please install fastText for Python: "
                         "https://github.com/facebookresearch/fastText")


### PR DESCRIPTION
as per June 25, 2019 (https://fasttext.cc/blog/2019/06/25/blog-post.html) the python module is named fastext. Since I don't want to change the fastText function, I just created an import alias