### PR TITLE
Reduce memory usage on loading embedding from txt

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -270,11 +270,13 @@ def read_txt_embeddings(params, source, full_vocab):
     lang = params.src_lang if source else params.tgt_lang
     emb_path = params.src_emb if source else params.tgt_emb
     _emb_dim_file = params.emb_dim
-    if not full_vocab:
+
+    with io.open(emb_path, 'r', encoding='utf-8', newline='\n', errors='ignore') as f:
+            vocab_size = sum([1 for _ in f])-1
+
+    if not full_vocab and params.max_vocab<vocab_size:
         embeddings = np.empty([params.max_vocab, params.emb_dim], dtype=np.float32)
     else:
-        with io.open(emb_path, 'r', encoding='utf-8', newline='\n', errors='ignore') as f:
-            vocab_size = sum([1 for _ in f])-1
         embeddings = np.empty([vocab_size, params.emb_dim], dtype=np.float32)
 
     with io.open(emb_path, 'r', encoding='utf-8', newline='\n', errors='ignore') as f:


### PR DESCRIPTION
Original implementation of read_txt_embeddings takes a lot of memory. For example, to load an embedding txt file that contains a vocab size of 2,000,000 with 300 embedding dimension, vectors list takes 64*300*2,000,000=4.8 GB, np.concatenate takes 4.8 GB and torch.from_numpy takes 2.4 GB, totally it takes around 12 GB.  Knowing vocab_size in advance and setting dtype of vector to np.float32, memory requirement can be reduced to around 2.4 GB instead of 12GB.